### PR TITLE
Add instructions

### DIFF
--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -86,8 +86,8 @@ describe("CPU", () => {
     };
 
     test("runs legal opcodes successfully", () => {
-      let target = "D1DA";
-      let tracing = false;
+      let target = "D8E2";
+      let tracing = true;
 
       let path = Util.expand_path("__tests__/roms/nestest.log");
       let lines = Node.Fs.readFileSync(path, `utf8) |> Js.String.split("\n");

--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -86,7 +86,7 @@ describe("CPU", () => {
     };
 
     test("runs legal opcodes successfully", () => {
-      let target = "CF00";
+      let target = "D1DA";
       let tracing = false;
 
       let path = Util.expand_path("__tests__/roms/nestest.log");

--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -104,9 +104,9 @@ describe("CPU", () => {
           let dis = disasm(previous_pc, 1);
           Js.log(
             {j|
-            Previous: $before
-            Expected: $line
-            Actual:   $after
+            Previous:    $before
+            Expected:    $line
+            Actual:      $after
             Disassembly: $dis
           |j},
           );

--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -86,7 +86,7 @@ describe("CPU", () => {
     };
 
     test("runs legal opcodes successfully", () => {
-      let target = "D8E2";
+      let target = "E1E4";
       let tracing = true;
 
       let path = Util.expand_path("__tests__/roms/nestest.log");

--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -86,8 +86,8 @@ describe("CPU", () => {
     };
 
     test("runs legal opcodes successfully", () => {
-      let target = "E1E4";
-      let tracing = true;
+      let target = "C6BD";
+      let tracing = false;
 
       let path = Util.expand_path("__tests__/roms/nestest.log");
       let lines = Node.Fs.readFileSync(path, `utf8) |> Js.String.split("\n");

--- a/__tests__/cpu_test.re
+++ b/__tests__/cpu_test.re
@@ -86,7 +86,7 @@ describe("CPU", () => {
     };
 
     test("runs legal opcodes successfully", () => {
-      let target = "CA05";
+      let target = "CF00";
       let tracing = false;
 
       let path = Util.expand_path("__tests__/roms/nestest.log");

--- a/__tests__/memory_test.re
+++ b/__tests__/memory_test.re
@@ -36,4 +36,10 @@ describe("Memory", () => {
 
     expect(word) == 0xc004;
   });
+
+  test("it can fetch a word with the page wraparound quirk", () => {
+    let word = Memory.get_indirect(memory, 0xffff);
+
+    expect(word) == 197;
+  });
 });

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -57,17 +57,19 @@ let decode = (json: Js.Json.t): t => {
 };
 
 let get_address = (cpu: Types.cpu, mode: t) => {
+  open Memory;
+
   switch (mode) {
   | Implicit => 0
   | Accumulator => cpu.acc
   | Immediate => cpu.pc
-  | ZeroPage => Memory.get_byte(cpu.memory, cpu.pc)
-  | Absolute => Memory.get_word(cpu.memory, cpu.pc)
+  | ZeroPage => get_byte(cpu.memory, cpu.pc)
+  | Absolute => get_word(cpu.memory, cpu.pc)
   | IndirectX =>
-    let start = Memory.get_byte(cpu.memory, cpu.pc) + cpu.x;
-    Memory.get_indirect(cpu.memory, start land 0xff);
+    let start = get_byte(cpu.memory, cpu.pc) + cpu.x;
+    get_indirect(cpu.memory, start land 0xff);
   | Relative =>
-    let offset = Memory.get_byte(cpu.memory, cpu.pc);
+    let offset = get_byte(cpu.memory, cpu.pc);
     if (Util.read_bit(offset, 7)) {
       cpu.pc - offset lxor 0xff;
     } else {

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -61,8 +61,11 @@ let get_address = (cpu: Types.cpu, mode: t) => {
   | Implicit => 0
   | Accumulator => cpu.acc
   | Immediate => cpu.pc
-  | Absolute => Memory.get_word(cpu.memory, cpu.pc)
   | ZeroPage => Memory.get_byte(cpu.memory, cpu.pc)
+  | Absolute => Memory.get_word(cpu.memory, cpu.pc)
+  | IndirectX =>
+    let start = Memory.get_byte(cpu.memory, cpu.pc) + cpu.x;
+    Memory.get_indirect(cpu.memory, start land 0xff);
   | Relative =>
     let offset = Memory.get_byte(cpu.memory, cpu.pc);
     if (Util.read_bit(offset, 7)) {

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -59,6 +59,7 @@ let decode = (json: Js.Json.t): t => {
 let get_address = (cpu: Types.cpu, mode: t) => {
   switch (mode) {
   | Implicit => 0
+  | Accumulator => cpu.acc
   | Immediate => cpu.pc
   | Absolute => Memory.get_word(cpu.memory, cpu.pc)
   | ZeroPage => Memory.get_byte(cpu.memory, cpu.pc)

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -65,9 +65,17 @@ let get_address = (cpu: Types.cpu, mode: t) => {
   | Immediate => cpu.pc
   | ZeroPage => get_byte(cpu.memory, cpu.pc)
   | Absolute => get_word(cpu.memory, cpu.pc)
+  | Indirect => get_indirect(cpu.memory, get_word(cpu.memory, cpu.pc));
   | IndirectX =>
     let start = get_byte(cpu.memory, cpu.pc) + cpu.x;
     get_indirect(cpu.memory, start land 0xff);
+  | IndirectY =>
+    let start = get_indirect(cpu.memory, get_byte(cpu.memory, cpu.pc));
+    let final = (start + cpu.y) land 0xffff;
+    if (start land 0xff00 != final land 0xff00) {
+      cpu.cycles = cpu.cycles + 1;
+    }
+    final;
   | Relative =>
     let offset = get_byte(cpu.memory, cpu.pc);
     if (Util.read_bit(offset, 7)) {

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -40,7 +40,7 @@ let decode = (json: Js.Json.t): t => {
   | Some(value) =>
     switch (value) {
     | "absolute" => Absolute
-    | "absoluteX" => AbsoluteY
+    | "absoluteX" => AbsoluteX
     | "absoluteY" => AbsoluteY
     | "accumulator" => Accumulator
     | "immediate" => Immediate

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -71,6 +71,8 @@ let get_address = (cpu: Types.cpu, mode: t) => {
   | Accumulator => cpu.acc
   | Immediate => cpu.pc
   | ZeroPage => get_byte(cpu.memory, cpu.pc)
+  | ZeroPageX => (get_byte(cpu.memory, cpu.pc) + cpu.x) land 0xff
+  | ZeroPageY => (get_byte(cpu.memory, cpu.pc) + cpu.y) land 0xff
   | Absolute => get_word(cpu.memory, cpu.pc)
   | AbsoluteX =>
   let start = get_word(cpu.memory, cpu.pc);
@@ -95,6 +97,5 @@ let get_address = (cpu: Types.cpu, mode: t) => {
     } else {
       cpu.pc + offset + 1;
     };
-  | _ => raise(NotImplemented(mode))
   };
 };

--- a/src/AddressingMode.re
+++ b/src/AddressingMode.re
@@ -13,26 +13,7 @@ type t =
   | ZeroPageY
   | Implicit;
 
-exception NotImplemented(t);
 exception Unrecognized(string);
-
-let inspect = (mode: t) => {
-  switch (mode) {
-  | Absolute => "absolute"
-  | AbsoluteX => "absoluteX"
-  | AbsoluteY => "absoluteY"
-  | Accumulator => "accumulator"
-  | Immediate => "immediate"
-  | Indirect => "indirect"
-  | IndirectX => "indirectX"
-  | IndirectY => "indirectY"
-  | Relative => "relative"
-  | ZeroPage => "zeroPage"
-  | ZeroPageX => "zeroPageX"
-  | ZeroPageY => "zeroPageY"
-  | Implicit => "implicit"
-  };
-};
 
 let decode = (json: Js.Json.t): t => {
   switch (Js.Json.decodeString(json)) {

--- a/src/Cpu.re
+++ b/src/Cpu.re
@@ -265,19 +265,12 @@ type error =
   | InstructionNotImplemented(string)
   | OpcodeNotFound(int);
 
-let step = (cpu: t): option(error) => {
+let step = (cpu: t) => {
   let opcode = Memory.get_byte(cpu.memory, cpu.pc);
   cpu.pc = cpu.pc + 1;
 
   switch (InstructionTable.find(opcode, table)) {
-  | command =>
-    switch (command(cpu)) {
-    | exception (AddressingMode.NotImplemented(mode)) =>
-      Some(AddressingModeNotImplemented(mode))
-    | exception (InstructionNotImplemented(ins)) =>
-      Some(InstructionNotImplemented(ins))
-    | _ => None
-    }
-  | exception Not_found => Some(OpcodeNotFound(opcode))
+  | command => command(cpu)
+  | exception Not_found => raise(OpcodeNotFound(opcode))
   };
 };

--- a/src/Cpu.re
+++ b/src/Cpu.re
@@ -256,6 +256,10 @@ let store_x = (cpu, argument) => {
   Memory.set_byte(cpu.memory, argument, cpu.x);
 };
 
+let store_y = (cpu, argument) => {
+  Memory.set_byte(cpu.memory, argument, cpu.y);
+};
+
 let subtract_with_borrow = (cpu, argument) => {
   let carry_bit = Flag.Register.get(cpu.status, Flag.Carry) ? 0 : 1;
   let result = cpu.acc - argument - carry_bit;
@@ -374,6 +378,7 @@ let handle = (definition: Instruction.t, opcode: Opcode.t, cpu: t) => {
     | "sei" => set_flag(Flag.InterruptDisable, true)
     | "sta" => store_acc
     | "stx" => store_x
+    | "sty" => store_y
     | "tax" => transfer_acc_to_x
     | "tay" => transfer_acc_to_y
     | "tsx" => transfer_stack_to_x

--- a/src/Cpu.re
+++ b/src/Cpu.re
@@ -345,14 +345,15 @@ let rmw_update = (opcode: Opcode.t, address) => {
 };
 
 let handle = (definition: Instruction.t, opcode: Opcode.t, cpu: t) => {
-  let address = AddressingMode.get_address(cpu, opcode.addressing_mode);
+  open AddressingMode;
+  let address = get_address(cpu, opcode.addressing_mode);
 
   let operand =
     switch (definition.access_pattern, opcode.addressing_mode) {
     | (Instruction.Static, _) => 0
     | (Instruction.Write, _) => address
     | (Instruction.Jump, _) => address
-    | (Instruction.ReadModifyWrite, AddressingMode.Accumulator) => address
+    | (Instruction.ReadModifyWrite, Accumulator) => address
     | _ => Memory.get_byte(cpu.memory, address)
     };
 

--- a/src/Cpu.re
+++ b/src/Cpu.re
@@ -146,7 +146,7 @@ let jump = (cpu, argument) => {
 };
 
 let jump_subroutine = (cpu, argument) => {
-  let target = cpu.pc + 2;
+  let target = cpu.pc + 1;
 
   stack_push(cpu, target lsr 8);
   stack_push(cpu, target land 0xff);
@@ -209,7 +209,7 @@ let return_from_subroutine = (cpu, _argument) => {
   let low = stack_pop(cpu);
   let high = stack_pop(cpu);
 
-  cpu.pc = high lsl 8 + low;
+  cpu.pc = high lsl 8 + low + 1;
 };
 
 let store_acc = (cpu, argument) => {

--- a/src/Cpu.re
+++ b/src/Cpu.re
@@ -25,12 +25,12 @@ let build = memory => {
   };
 };
 
-let check_overflow = (result, acc, arg)  => {
+let check_overflow = (result, acc, arg) => {
   let result_sign = Util.read_bit(result, 7);
   let acc_sign = Util.read_bit(acc, 7);
   let arg_sign = Util.read_bit(arg, 7);
-  !(result_sign == acc_sign || result_sign == arg_sign)
-}
+  !(result_sign == acc_sign || result_sign == arg_sign);
+};
 
 let copy = cpu => {
   ...cpu,
@@ -77,12 +77,16 @@ let stack_push = (cpu: t, value: int) => {
 let add_with_carry = (cpu, argument) => {
   let carry_bit = Flag.Register.to_int(cpu.status) land 1;
   let result = cpu.acc + argument + carry_bit;
-  Flag.Register.set(cpu.status, Flag.Overflow, check_overflow(result, cpu.acc, argument));
+  Flag.Register.set(
+    cpu.status,
+    Flag.Overflow,
+    check_overflow(result, cpu.acc, argument),
+  );
   Flag.Register.set(cpu.status, Flag.Carry, result > 0xff);
   cpu.acc = result land 0xff;
 
   set_flags_zn(cpu, cpu.acc);
-}
+};
 
 let and_with_acc = (cpu, argument) => {
   cpu.acc = cpu.acc land argument;
@@ -98,9 +102,19 @@ let branch_on_flag = (flag, expected, cpu, argument) =>
     cpu.pc = cpu.pc + 1;
   };
 
-let compare = (cpu, argument) => {
+let compare_acc = (cpu, argument) => {
   set_flags_zn(cpu, cpu.acc - argument);
   Flag.Register.set(cpu.status, Flag.Carry, cpu.acc >= argument);
+};
+
+let compare_x = (cpu, argument) => {
+  set_flags_zn(cpu, cpu.x - argument);
+  Flag.Register.set(cpu.status, Flag.Carry, cpu.x >= argument);
+};
+
+let compare_y = (cpu, argument) => {
+  set_flags_zn(cpu, cpu.y - argument);
+  Flag.Register.set(cpu.status, Flag.Carry, cpu.y >= argument);
 };
 
 let jump = (cpu, argument) => {
@@ -128,6 +142,12 @@ let load_x = (cpu, argument) => {
   set_flags_zn(cpu, cpu.x);
 };
 
+let load_y = (cpu, argument) => {
+  cpu.y = argument;
+
+  set_flags_zn(cpu, cpu.y);
+};
+
 let nop = (_cpu, _argument) => {
   ();
 };
@@ -135,7 +155,7 @@ let nop = (_cpu, _argument) => {
 let or_with_acc = (cpu, argument) => {
   cpu.acc = cpu.acc lor argument;
   set_flags_zn(cpu, cpu.acc);
-}
+};
 
 let pop_acc = (cpu, _argument) => {
   cpu.acc = stack_pop(cpu);
@@ -145,16 +165,20 @@ let pop_acc = (cpu, _argument) => {
 
 let pop_status = (cpu, _argument) => {
   // See https://wiki.nesdev.com/w/index.php/Status_flags#The_B_flag
-  cpu.status = Flag.Register.from_int(stack_pop(cpu) lor 0x20 land 0xef);
-}
+  cpu.status =
+    Flag.Register.from_int(stack_pop(cpu) lor 0x20 land 0xef);
+};
 
 let push_acc = (cpu, _argument) => {
   stack_push(cpu, cpu.acc);
-}
+};
 
 let push_status = (cpu, _argument) => {
   // See https://wiki.nesdev.com/w/index.php/Status_flags#The_B_flag
-  stack_push(cpu, Flag.Register.to_int(cpu.status) lor 0x10);
+  stack_push(
+    cpu,
+    Flag.Register.to_int(cpu.status) lor 0x10,
+  );
 };
 
 let return_from_subroutine = (cpu, _argument) => {
@@ -181,7 +205,7 @@ let test_bits = (cpu, argument) => {
 let xor_with_acc = (cpu, argument) => {
   cpu.acc = cpu.acc lxor argument;
   set_flags_zn(cpu, cpu.acc);
-}
+};
 
 let step_size = (definition: Instruction.t, opcode: Opcode.t) => {
   switch (definition.access_pattern) {
@@ -216,12 +240,15 @@ let handle = (definition: Instruction.t, opcode: Opcode.t, cpu: t) => {
     | "clc" => set_flag(Flag.Carry, false)
     | "cld" => set_flag(Flag.Decimal, false)
     | "clv" => set_flag(Flag.Overflow, false)
-    | "cmp" => compare
+    | "cmp" => compare_acc
+    | "cpx" => compare_x
+    | "cpy" => compare_y
     | "eor" => xor_with_acc
     | "jmp" => jump
     | "jsr" => jump_subroutine
     | "lda" => load_acc
     | "ldx" => load_x
+    | "ldy" => load_y
     | "nop" => nop
     | "ora" => or_with_acc
     | "pha" => push_acc

--- a/src/Memory.re
+++ b/src/Memory.re
@@ -35,7 +35,7 @@ let get_word = (mem: t, loc: int) => {
 let get_indirect = (mem: t, loc: int) => {
   // If an indirect fetch would wrap to the next page,
   // it instead wraps to the beginning of the current page.
-  let wrapped = loc land 0xff00 + (loc + 1 land 0xff);
+  let wrapped = loc land 0xff00 + (loc + 1) land 0xff;
   let low = get_byte(mem, loc);
   let high = get_byte(mem, wrapped);
   high lsl 8 + low;

--- a/src/Memory.re
+++ b/src/Memory.re
@@ -31,3 +31,12 @@ let get_word = (mem: t, loc: int) => {
   let high = get_byte(mem, loc + 1);
   high lsl 8 + low;
 };
+
+let get_indirect = (mem: t, loc: int) => {
+  // If an indirect fetch would wrap to the next page,
+  // it instead wraps to the beginning of the current page.
+  let wrapped = loc land 0xff00 + (loc + 1 land 0xff);
+  let low = get_byte(mem, loc);
+  let high = get_byte(mem, wrapped);
+  high lsl 8 + low;
+}


### PR DESCRIPTION
We're now failing with

    Previous:    CE42 A:69 X:7E Y:01 P:27 SP:7E CYC:2022
    Expected:    CE43 A:39 X:7E Y:01 P:25 SP:7F CYC:2026
    Actual:      CE43 A:3A X:7E Y:01 P:25 SP:7F CYC:2026
    Disassembly: CE42 68       ;; PLA

so something appears to be going wrong with either our stack state or (likely) the newly-implemented transfer-x-with-stack instructions.

I tweaked the error handling and messaging a bit to always show the previous log line along with the instruction that produced the unexpected state.